### PR TITLE
migrate hiera.yaml and metadata.json to hiera v5.

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,9 +1,10 @@
 ---
-version: 4
-datadir: data
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
 hierarchy:
   - name: "OS family"
-    backend: yaml
-    path: "os/%{facts.os.family}"
-  - name: default
-    backend: yaml
+    path: "os/%{facts.os.family}.yaml"
+  - name: "default"
+    path: default.yaml

--- a/metadata.json
+++ b/metadata.json
@@ -36,6 +36,5 @@
     "version_requirement": "4.x"
     }
   ],
-  "dependencies": [],
-  "data_provider": "hiera"
+  "dependencies": []
 }


### PR DESCRIPTION
Changed hiera.yaml and metadata.json to remove depreciation warnings.