### PR TITLE
Removed create_resources function

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,10 +9,15 @@ class sysctl (Boolean $purge,
               String  $sysctl_dir_mode) {
 
   $defaults = {
-    sysctl_binary   => $sysctl_binary,
-    sysctl_dir_path => $sysctl_dir_path,
+    'sysctl_binary'   => $sysctl_binary,
+    'sysctl_dir_path' => $sysctl_dir_path,
   }
-  create_resources(sysctl::configuration, $values, $defaults)
+
+  $values.each | String $val, Hash $params | {  
+    sysctl::configuration { $val:
+      * => $defaults + $params,
+    }
+  }
 
   if $sysctl_dir {
     # if we're purging we should also recurse


### PR DESCRIPTION

This PR removes the need for using the dated `create_resources()` function to generate the `sysctl::configuration` entries.  This is replaced with an iterator

Also fixed quoting issue on the `$defaults` hash

